### PR TITLE
Feat: extend linter rules

### DIFF
--- a/python-minimal/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/python-minimal/{{cookiecutter.project_slug}}/pyproject.toml
@@ -39,7 +39,7 @@ line-length = 88
 {%- if cookiecutter.use_ruff_lint %}
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["B", "I", "RUF1", "UP", "W"]
 
 [tool.ruff.lint.isort]
 lines-after-imports = 2


### PR DESCRIPTION
Fix #1, adding:
 * [Warning (W)](https://docs.astral.sh/ruff/rules/#warning-w)
 * [flake8-bugbear (B)](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b)
 * [pyupgrade (UP)](https://docs.astral.sh/ruff/rules/#pyupgrade-up)
 * RUF1, a subset of [Ruff-specific rules (RUF)](https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf) 