### PR TITLE
Fix: Do not add `-e .` to `requirements.txt`

### DIFF
--- a/python-minimal/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/python-minimal/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -33,6 +33,7 @@ repos:
   hooks:
     - id: uv-lock
     - id: uv-export
+      args: ["--frozen", "--no-emit-project", "--output-file=requirements.txt", "--quiet"]
 {%- else %}
 - repo: local
   hooks:


### PR DESCRIPTION
Including the project in editable mode when using hashes leads to:

```
ERROR: The editable requirement file://<path> (from -r requirements.txt (line 3)) cannot be installed when requiring hashes, because there is no single file to hash.
```